### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -11,28 +11,28 @@ const Hero = () => (
       style={{ backgroundImage: 'url(/edge-detect.jpg)' }}
     />
     {/* Dark overlay */}
-    <div className="absolute inset-0 bg-black/70" />
+    <div className="absolute inset-0 bg-white/70 dark:bg-black/70" />
 
     {/* Centered content */}
     <div className="relative z-10 mx-auto flex h-full max-w-3xl flex-col items-center justify-center px-6 text-center">
-      <h1 className="mb-4 mt-16 text-6xl md:text-8xl font-bold text-white drop-shadow-lg">
+      <h1 className="mb-4 mt-16 text-6xl md:text-8xl font-bold text-black dark:text-white drop-shadow-lg">
         Adam Ross
       </h1>
-      <p className="mb-8 text-lg md:text-2xl text-gray-300">
+      <p className="mb-8 text-lg md:text-2xl text-gray-700 dark:text-gray-300">
         Data specialist who loves building with Python and TypeScript
       </p>
       <div className="mb-10 flex space-x-5">
         <a
           href="/resume.pdf"
-          className="px-6 py-3 bg-white text-black rounded-md shadow hover:bg-gray-100 transition"
+          className="px-6 py-3 bg-black text-white rounded-md shadow hover:bg-gray-800 transition dark:bg-white dark:text-black dark:hover:bg-gray-100"
         >
           Resume
         </a>
-        <button className="px-6 py-3 bg-transparent border border-white text-white rounded-md hover:bg-white/10 transition">
+        <button className="px-6 py-3 bg-transparent border border-black text-black rounded-md hover:bg-black/10 transition dark:border-white dark:text-white dark:hover:bg-white/10">
           Get in Touch
         </button>
       </div>
-      <div className="flex space-x-6 text-white text-2xl">
+      <div className="flex space-x-6 text-black dark:text-white text-2xl">
          <a
           href="https://www.linkedin.com/in/adam-ross-34b79478/"
           target="_blank"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 // src/components/Navbar.jsx
 import React, { useState, useEffect } from 'react'
+import { FaMoon, FaSun } from 'react-icons/fa'
 
 const projects = [
   { name: 'coderview',       href: '/projects/coderview' },
@@ -11,17 +12,28 @@ const projects = [
 
 export default function Navbar() {
   const [currentPath, setCurrentPath] = useState('')
+  const [theme, setTheme] = useState(
+    document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+  )
+
   useEffect(() => {
     setCurrentPath(window.location.pathname)
   }, [])
 
+  const toggleTheme = () => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark'
+    setTheme(newTheme)
+    document.documentElement.classList.toggle('dark')
+    localStorage.setItem('theme', newTheme)
+  }
+
   return (
-    <header className="fixed inset-x-0 top-0 z-50 bg-black backdrop-blur-lg border-b border-white/20">
+    <header className="fixed inset-x-0 top-0 z-50 bg-white dark:bg-black backdrop-blur-lg border-b border-black/10 dark:border-white/20">
       <div className="container mx-auto flex h-20 items-center px-6">
         {/* WR square logo */}
         <a
           href="/"
-          className="flex h-10 w-10 items-center justify-center bg-white/10 text-white font-bold rounded-sm"
+          className="flex h-10 w-10 items-center justify-center bg-black/10 text-black font-bold rounded-sm dark:bg-white/10 dark:text-white"
         >
           AR
         </a>
@@ -37,8 +49,8 @@ export default function Navbar() {
                 className={
                   `px-3 py-1 rounded-md transition-colors ` +
                   (isActive
-                    ? 'bg-white/20 text-white'
-                    : 'text-white/80 hover:text-white hover:bg-white/10')
+                    ? 'bg-black/20 text-black dark:bg-white/20 dark:text-white'
+                    : 'text-black/80 hover:text-black hover:bg-black/10 dark:text-white/80 dark:hover:text-white dark:hover:bg-white/10')
                 }
               >
                 {name}
@@ -47,9 +59,13 @@ export default function Navbar() {
           })}
         </nav>
 
-        {/* CTA button */}
-        <button className="ml-auto px-4 py-2 bg-white text-black rounded-md shadow-sm hover:shadow transition-shadow">
-          Get in Touch
+        {/* Theme toggle */}
+        <button
+          onClick={toggleTheme}
+          className="ml-auto p-2 rounded-md bg-black text-white dark:bg-white dark:text-black shadow-sm hover:shadow transition-shadow"
+          aria-label="Toggle theme"
+        >
+          {theme === 'dark' ? <FaSun /> : <FaMoon />}
         </button>
       </div>
     </header>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -5,7 +5,7 @@ import { projects } from '../data/projects'
 
 export default function Projects() {
   return (
-    <section id="projects" className="py-20 bg-black text-white">
+    <section id="projects" className="py-20 bg-white text-black dark:bg-black dark:text-white">
       <div className="max-w-7xl mx-auto px-4">
         <h2 className="text-4xl font-bold mb-12 text-center">Featured Projects</h2>
 
@@ -20,7 +20,7 @@ export default function Projects() {
                 className={`flex ${containerOrder} items-center px-4 py-12 gap-12`}
               >
                 {/* MEDIA SIDE */}
-                <div className="flex-1 h-64 lg:h-80 overflow-hidden rounded-lg shadow-lg bg-gray-900">
+                <div className="flex-1 h-64 lg:h-80 overflow-hidden rounded-lg shadow-lg bg-gray-200 dark:bg-gray-900">
                   {project.mediaType === 'video' ? (
                     <video
                       src={project.mediaUrl}
@@ -42,10 +42,10 @@ export default function Projects() {
                 {/* TEXT SIDE */}
                 <div className="flex-1 space-y-4">
                   <h3 className="text-3xl py-2 font-bold">{project.title}</h3>
-                  <p className="text-lg py-2 text-gray-300">{project.shortDesc}</p>
+                  <p className="text-lg py-2 text-gray-700 dark:text-gray-300">{project.shortDesc}</p>
                   <Link
                     to={`/projects/${project.slug}`}
-                    className="inline-flex items-center text-white font-medium hover:underline"
+                    className="inline-flex items-center text-black font-medium hover:underline dark:text-white"
                   >
                     View Project →
                   </Link>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,15 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
+// Initialize theme based on localStorage or system preference
+const storedTheme = localStorage.getItem('theme')
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
+  document.documentElement.classList.add('dark')
+} else {
+  document.documentElement.classList.remove('dark')
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,7 +6,7 @@ import Projects from '../components/Projects'
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-white text-black dark:bg-black dark:text-white">
       <Navbar />
       <Hero />
       <Projects />

--- a/src/pages/ProjectPage.jsx
+++ b/src/pages/ProjectPage.jsx
@@ -1,9 +1,8 @@
-// src/pages/ProjectPage.jsx
 import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import Navbar from '../components/Navbar'
 import { projects } from '../data/projects'
-import { FaGithub, FaGlobe } from 'react-icons/fa'       
+import { FaGithub, FaGlobe } from 'react-icons/fa'
 
 export default function ProjectPage() {
   const { slug } = useParams()
@@ -13,10 +12,10 @@ export default function ProjectPage() {
     return (
       <>
         <Navbar />
-        <div className="mt-20 flex items-center justify-center h-screen bg-black">
-          <p className="text-white">
-            Project “{slug}” not found.{' '}
-            <Link to="/" className="underline text-blue-400">
+        <div className="mt-20 flex items-center justify-center h-screen bg-white text-black dark:bg-black dark:text-white">
+          <p>
+            Project “{slug}” not found.{` `}
+            <Link to="/" className="underline text-blue-600 dark:text-blue-400">
               Go back home
             </Link>
             .
@@ -30,12 +29,12 @@ export default function ProjectPage() {
     <>
       <Navbar />
 
-      {/* FULL-WIDTH BLACK WRAPPER */}
-      <div className="bg-black text-white pt-20 min-h-screen">
+      {/* FULL-WIDTH WRAPPER */}
+      <div className="bg-white text-black dark:bg-black dark:text-white pt-20 min-h-screen">
         {/* HEADER: two-column on md+, single on mobile */}
         <div className="max-w-7xl mx-auto flex flex-row items-center px-6 py-12 gap-12">
           {/* LEFT: video or image */}
-          <div className="w-full md:w-1/2 h-64 md:h-80 lg:h-96 overflow-hidden rounded-lg shadow-lg bg-gray-900">
+          <div className="w-full md:w-1/2 h-64 md:h-80 lg:h-96 overflow-hidden rounded-lg shadow-lg bg-gray-200 dark:bg-gray-900">
             {project.mediaType === 'video' ? (
               <video
                 src={project.mediaUrl}
@@ -47,7 +46,7 @@ export default function ProjectPage() {
               />
             ) : (
               <img
-                src={project.mediaUrl}               
+                src={project.mediaUrl}
                 alt={project.title}
                 className="w-full h-full object-cover"
               />
@@ -57,13 +56,15 @@ export default function ProjectPage() {
           {/* RIGHT: title, blurb, icon buttons */}
           <div className="w-full md:w-1/2 space-y-6">
             <h1 className="text-5xl font-extrabold">{project.title}</h1>
-            <p className="text-lg md:text-xl text-gray-300">{project.shortDesc}</p>
+            <p className="text-lg md:text-xl text-gray-700 dark:text-gray-300">
+              {project.shortDesc}
+            </p>
             <div className="flex flex-wrap gap-4">
               <a
                 href={project.repoUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center px-6 py-3 bg-white text-black rounded-md shadow hover:opacity-90 transition"
+                className="inline-flex items-center px-6 py-3 bg-black text-white rounded-md shadow hover:opacity-90 transition dark:bg-white dark:text-black"
               >
                 <FaGithub className="mr-2" /> View on GitHub
               </a>
@@ -71,7 +72,7 @@ export default function ProjectPage() {
                 href={project.siteUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center px-6 py-3 bg-transparent border border-white text-white rounded-md hover:bg-white/20 transition"
+                className="inline-flex items-center px-6 py-3 bg-transparent border border-black text-black rounded-md hover:bg-black/10 transition dark:border-white dark:text-white dark:hover:bg-white/20"
               >
                 <FaGlobe className="mr-2" /> Visit Site
               </a>
@@ -83,8 +84,8 @@ export default function ProjectPage() {
         <div className="max-w-3xl mx-auto px-6 py-12 space-y-12">
           {project.sections.map((sec, idx) => (
             <section key={idx} className="space-y-4">
-              <h2 className="text-2xl md:text-3xl font-bold">{sec.heading}</h2>  
-              <p className="text-lg md:text-xl">{sec.content}</p>            
+              <h2 className="text-2xl md:text-3xl font-bold">{sec.heading}</h2>
+              <p className="text-lg md:text-xl">{sec.content}</p>
               {sec.image && (
                 <figure>
                   <img
@@ -93,7 +94,7 @@ export default function ProjectPage() {
                     className="rounded-lg shadow-lg"
                   />
                   {sec.caption && (
-                    <figcaption className="text-sm text-gray-400 mt-2">
+                    <figcaption className="text-sm text-gray-600 dark:text-gray-400 mt-2">
                       {sec.caption}
                     </figcaption>
                   )}
@@ -103,7 +104,7 @@ export default function ProjectPage() {
           ))}
 
           <div className="text-center">
-            <Link to="/" className="underline text-blue-400">
+            <Link to="/" className="underline text-blue-600 dark:text-blue-400">
               ← Back to home
             </Link>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,jsx,ts,tsx,css,html}',


### PR DESCRIPTION
## Summary
- Replace navbar call-to-action with a light/dark theme toggle
- Configure Tailwind for class-based dark mode and load saved/system preference on startup
- Style home and project pages to support both light and dark themes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b81ab6e3f8832d9490ec7cd2f5c279